### PR TITLE
Swagger specification endpoint and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ curl -u $BACKSTAGE_USERNAME http://maven.forgerock.org/repo/private-releases/set
 
 ### Build the project
 
-#### Compile
+#### Maven build
 
 From the command line, simply run:
 
@@ -20,9 +20,95 @@ From the command line, simply run:
 mvn clean install
 ```
 
-This will run any JUnit/Spring integration tests and build the required JAR files and docker images.
+This will run any JUnit/Spring integration tests and build the required JAR file and docker image.
 
-#### Swagger Code Generation
+### How to run
+Either run the docker image created in the previous step, or run the project's SpringBoot application class:
+
+```com.forgerock.securebanking.openbanking.aspsp.AspspSimulatorApplication``` 
+
+Note that the application has a dependency on MongoDB and will not start up without it. If running locally, this can be
+achieved by simply starting up Mongo on its default port (27017) - for example by running a MongoDB docker image.
+
+### Supported APIs
+Upon starting the application, a list of supported APIs can be obtained dynamically from two different endpoints:
+
+1. Discovery Endpoint
+1. Swagger Specification Endpoint
+ 
+#### Discovery Endpoint
+The application has a "Discovery Endpoint" which lists all the supported URLs. This is the Open Banking Read/Write API
+that the application has implemented. The Discovery Endpoint can be viewed in a browser by visiting:
+
+```http://<host>:<port>/open-banking/discovery```
+
+> Substitute `<host>` and `<port` as necessary
+
+#### Swagger Specification Endpoint
+The application's swagger documentation can be obtained from the following URL:
+
+```http://<host>:<port>/api-docs``` 
+
+> Substitute `<host>` and `<port` as necessary
+
+This provides the full swagger specification, including the Open Banking Read/Write Apis that the application is able
+to support (regardless of whether they have been disabled in the configuration). Importantly, this reveals any
+additional headers or request parameters that are required by the simulator.
+
+> Any additional headers/parameters will be provided automatically to a bank's ASPSP, if it is used instead
+>of ForgeRock's ASPSP simulator).
+
+#### Enable/Disable API Endpoints
+By default, all implemented API endpoints are enabled, however it is possible to explicitly disable them in the
+application's config.
+
+```
+aspsp:
+  discovery:
+    financialId: 0015800001041REAAY
+    versions:
+      # v3.0 to v3.1.4 are enabled by default but set to `true` here for completeness
+      v3.0: true
+      v3.1: true
+      v3.1.1: true
+      v3.1.2: true
+      v3.1.3: true
+      v3.1.4: true
+
+      # Disable all v3.1.5 and v3.1.6 endpoints
+      v3.1.5: false
+      v3.1.6: false
+
+    apis:
+      # Disable Create/Get DomesticPaymentConsent across all versions
+        CreateDomesticPaymentConsent: false      
+        GetDomesticPaymentConsent: false
+
+    versionApiOverrides:
+      # Disable Get statement endpoints in v3.1.3 and v3.1.4
+      v3_1_3:
+        GetStatements: false
+        GetAccountStatements: false
+      v3_1_4:
+        GetStatements: false
+        GetAccountStatements: false
+```
+
+As can be deduced from this config, Read/Write API endpoints can be disabled (resulting in a 404 error response) by one
+of three ways:
+
+1. **versions**: By specifying a complete version of the API to block. In the above example, any requests to v3.1.4
+or v3.1.5 will be blocked.
+1. **apis**: By specifying the name of the endpoint (which can be derived from the Discovery endpoint). In the above
+example, `CreateDomesticPaymentConsent` and `GetDomesticPaymentConsent` are disabled in all versions.
+1. **versionApiOverrides**: Or more specifically, by listing both the version and name of the endpoint. In the above
+example, `GetStatements` and `GetAccountStatements` will be blocked in v3.1.3 and v3.1.4, but will work in the versions
+prior to this.
+
+*********************************************************************
+## TODO - move the following section to common's uk-datamodel project
+*********************************************************************
+### Open Banking Model Generation
 The project is set-up to make it easy to generate the OB model classes and skeleton API classes.
 For efficiency, the default maven profile does not generate the code, but it is simple to do so by 
 running the `code-gen` profile - for example:

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <java.version>11</java.version>
 
         <validation-api.version>2.0.1.Final</validation-api.version>
-        <springfox.version>2.10.5</springfox.version>
+        <springfox.version>3.0.0</springfox.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <joda-time.version>2.10.8</joda-time.version>
         <jackson-joda.version>2.9.7</jackson-joda.version>
@@ -92,6 +92,12 @@
                 <artifactId>springfox-swagger-ui</artifactId>
                 <version>${springfox.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-boot-starter</artifactId>
+                <version>${springfox.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>

--- a/securebanking-openbanking-aspsp-model/pom.xml
+++ b/securebanking-openbanking-aspsp-model/pom.xml
@@ -46,7 +46,8 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
         </dependency>
-        <!--SpringFox dependencies -->
+
+        <!-- Swagger -->
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>

--- a/securebanking-openbanking-aspsp-simulator/pom.xml
+++ b/securebanking-openbanking-aspsp-simulator/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>spring-boot-starter-hateoas</artifactId>
         </dependency>
 
+        <!-- swagger -->
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-boot-starter</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/configuration/SwaggerDocumentationConfig.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/configuration/SwaggerDocumentationConfig.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.configuration;
+
+import com.forgerock.securebanking.openbanking.aspsp.discovery.DiscoveryApiService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.ApiSelectorBuilder;
+import springfox.documentation.spring.web.plugins.Docket;
+import uk.org.openbanking.datamodel.discovery.GenericOBDiscoveryAPILinks;
+import uk.org.openbanking.datamodel.discovery.OBDiscoveryAPI;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static springfox.documentation.builders.PathSelectors.any;
+
+@javax.annotation.Generated(value = "io.swagger.codegen.languages.SpringCodegen", date = "2017-10-11T14:17:28.882Z")
+
+/**
+ * Configuration class for the application's Swagger specification. Refer to the project's README.md for more
+ * information.
+ */
+@Configuration
+@PropertySource("classpath:messages/swagger.properties")
+public class SwaggerDocumentationConfig {
+
+    @Value("${swagger.title}")
+    public String swaggerTitle;
+    @Value("${swagger.description}")
+    public String swaggerDescription;
+    @Value("${swagger.license}")
+    public String swaggerLicense;
+    @Value("${swagger.license-url}")
+    public String swaggerLicenseUrl;
+    @Value("${swagger.terms-of-service-url}")
+    public String swaggerTermsOfServiceUrl;
+    @Value("${swagger.version}")
+    public String swaggerVersion;
+    @Value("${swagger.contact.name}")
+    public String swaggerContactName;
+    @Value("${swagger.contact.url}")
+    public String swaggerContactUrl;
+    @Value("${swagger.contact.email}")
+    public String swaggerContactEmail;
+
+    @Autowired
+    private DiscoveryApiService discoveryApiService;
+
+    ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title(swaggerTitle)
+                .description(swaggerDescription)
+                .license(swaggerLicense)
+                .licenseUrl(swaggerLicenseUrl)
+                .termsOfServiceUrl(swaggerTermsOfServiceUrl)
+                .contact(new Contact(swaggerContactName, swaggerContactUrl, swaggerContactEmail))
+                .build();
+    }
+
+    @Bean
+    public Docket customImplementation(@Value("${aspsp.baseUrl}") String baseUrl) {
+        ApiSelectorBuilder select = new Docket(DocumentationType.SWAGGER_2)
+                .ignoredParameterTypes(Principal.class)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.forgerock.securebanking.openbanking.aspsp"));
+
+        for (Map<String, OBDiscoveryAPI> entry : discoveryApiService.getDiscoveryApis().values()) {
+            for (OBDiscoveryAPI obDiscoveryAPI : entry.values()) {
+                GenericOBDiscoveryAPILinks genericOBDiscoveryAPILinks = (GenericOBDiscoveryAPILinks) obDiscoveryAPI.getLinks();
+                genericOBDiscoveryAPILinks.getLinks().values()
+                        .forEach(link -> link.replaceFirst(baseUrl, ""));
+            }
+        }
+
+        return select
+                .paths(any())
+                .build()
+                .directModelSubstitute(org.joda.time.LocalDate.class, java.sql.Date.class)
+                .directModelSubstitute(org.joda.time.DateTime.class, java.util.Date.class)
+                .apiInfo(apiInfo());
+    }
+
+}

--- a/securebanking-openbanking-aspsp-simulator/src/main/resources/application.yml
+++ b/securebanking-openbanking-aspsp-simulator/src/main/resources/application.yml
@@ -658,3 +658,10 @@ aspsp:
           GetEventSubscription: ${aspsp.baseUrl}/open-banking/v3.1.6/event-subscriptions
           AmendEventSubscription: ${aspsp.baseUrl}/open-banking/v3.1.6/event-subscriptions/{EventSubscriptionId}
           DeleteEventSubscription: ${aspsp.baseUrl}/open-banking/v3.1.6/event-subscriptions/{EventSubscriptionId}
+
+#Swagger
+springfox:
+  documentation:
+    swagger:
+      v2:
+        path: /api-docs

--- a/securebanking-openbanking-aspsp-simulator/src/main/resources/messages/swagger.properties
+++ b/securebanking-openbanking-aspsp-simulator/src/main/resources/messages/swagger.properties
@@ -1,0 +1,10 @@
+# Swagger Specification endpoint properties
+swagger.title=Payment initiation and Account information APIs Specification
+swagger.description=Swagger for Payment initiation and Account information APIs Specification
+swagger.license=open-licence
+swagger.license-url=https://www.openbanking.org.uk/open-licence
+swagger.terms-of-service-url=https://backstage.forgerock.com/knowledge/openbanking/article/a45894685
+swagger.version=v3.1.6
+swagger.contact.name=ForgeRock ASPSP Simulator
+swagger.contact.url=https://www.forgerock.com/
+swagger.contact.email=openbanking-support@forgerock.com


### PR DESCRIPTION
This PR:

 - Adds an endpoint to retrieve the full swagger specification
 - Adds documentation to the README.md, including how to enable/disable API endpoints.

Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#5