### PR TITLE
8: Dockerize the ASPSP simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAccelerat
 
 Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/2
 ### GitHub [#5](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/pull/5) 2: Add CHANGELOG.md generation to pom.xml
+[245861e14329568](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/245861e14329568) Matt Wills *2020-12-08 10:22:15*
+5: Swagger specification endpoint (#9)
+
+- Add endpoint to retrieve full swagger specification
+ - Add documentation to README.md detailing how to enable/disable API endpoints.
+
+Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#5
+[cb5ff36119a07df](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/cb5ff36119a07df) Matt Wills *2020-12-07 10:47:35*
+5: Discovery blacklist functionality (#8)
+
+- Reject requests (with a 404) to any API endpoint that has been explicitly disabled in the config
+
+Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#5
 [dc28150f705fe9e](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/dc28150f705fe9e) Matt Wills *2020-12-02 09:59:26*
 5: Load all API endpoints from config (#7)
 
@@ -52,6 +65,21 @@ Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAccelerat
 
 - Load all available Read/Write API endpoints from application.yml
 - Filter supported APIs according to customer's config (if applicable)
+
+Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#5
+### GitHub [#8](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/pull/8) Discovery blacklist functionality
+[cb5ff36119a07df](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/cb5ff36119a07df) Matt Wills *2020-12-07 10:47:35*
+5: Discovery blacklist functionality (#8)
+
+- Reject requests (with a 404) to any API endpoint that has been explicitly disabled in the config
+
+Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#5
+### GitHub [#9](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/pull/9) Swagger specification endpoint and README update
+[245861e14329568](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/245861e14329568) Matt Wills *2020-12-08 10:22:15*
+5: Swagger specification endpoint (#9)
+
+- Add endpoint to retrieve full swagger specification
+ - Add documentation to README.md detailing how to enable/disable API endpoints.
 
 Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#5
 [b4d0e28645d0542](https://github.com/SecureBankingAcceleratorToolkit/securebanking-openbanking-aspsp/commit/b4d0e28645d0542) Matt Wills *2020-11-19 13:05:05*

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <license-maven-plugin.version>3.0</license-maven-plugin.version>
         <openapi-generator.version>4.3.1</openapi-generator.version>
         <git-changelog-maven-plugin.version>1.63</git-changelog-maven-plugin.version>
+        <jib-maven-plugin.version>2.5.2</jib-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -243,6 +244,37 @@
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>
                     <version>${openapi-generator.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>${jib-maven-plugin.version}</version>
+                    <configuration>
+                        <from>
+                            <image>openjdk:11-jre</image>
+                        </from>
+                        <to>
+                            <image>eu.gcr.io/openbanking-214714/securebanking/ob-aspsp-simulator</image>
+                            <tags>
+                                <tag>${project.version}</tag>
+                                <tag>latest</tag>
+                            </tags>
+                        </to>
+                        <container>
+                            <jvmFlags>
+                                <jvmFlag>-Xms512m</jvmFlag>
+                                <jvmFlag>-Xdebug</jvmFlag>
+                            </jvmFlags>
+                        </container>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>build</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/securebanking-openbanking-aspsp-simulator/docker-compose.yml
+++ b/securebanking-openbanking-aspsp-simulator/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.1'
+services:
+
+  aspsp-simulator:
+    container_name: aspsp-simulator
+    image: eu.gcr.io/openbanking-214714/securebanking/ob-aspsp-simulator:latest
+    ports:
+      - 8080:8080
+    environment:
+      - spring.data.mongodb.host=aspsp-mongo
+    links:
+      - aspsp-mongo
+
+  aspsp-mongo:
+    container_name: aspsp-mongo
+    image: mongo:4.4.2
+    ports:
+      - 27017:27017

--- a/securebanking-openbanking-aspsp-simulator/pom.xml
+++ b/securebanking-openbanking-aspsp-simulator/pom.xml
@@ -149,6 +149,10 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This PR introduces:

 - The jib-maven-plugin to push docker image to our gcr docker registry during maven build
 - A docker-compose file to start up the ASPSP simulator with MongoDB

Issue: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#8