### PR TITLE
6: Fix outstanding issues in DomesticPaymentConsentsApiController

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,8 @@
                     <version>${jib-maven-plugin.version}</version>
                     <configuration>
                         <from>
-                            <image>openjdk:11-jre</image>
+                            <!-- TODO #8 - use JRE instead of JDK -->
+                            <image>openjdk:14-alpine</image>
                         </from>
                         <to>
                             <image>eu.gcr.io/openbanking-214714/securebanking/ob-aspsp-simulator</image>

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/api/common/IntentType.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/api/common/IntentType.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.api.common;
+
+import com.forgerock.securebanking.openbanking.aspsp.common.OBGroupName;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.forgerock.securebanking.openbanking.aspsp.common.OBGroupName.*;
+
+public enum IntentType {
+
+    ACCOUNT_REQUEST("AR_", AISP),
+    PAYMENT_SINGLE_REQUEST("PR_", PISP),
+
+    ACCOUNT_ACCESS_CONSENT("AAC_", AISP),
+
+    PAYMENT_DOMESTIC_CONSENT("PDC_", PISP),
+    PAYMENT_DOMESTIC_SCHEDULED_CONSENT("PDSC_", PISP),
+    PAYMENT_DOMESTIC_STANDING_ORDERS_CONSENT("PDSOC_", PISP),
+    PAYMENT_INTERNATIONAL_CONSENT("PIC_", PISP),
+    PAYMENT_INTERNATIONAL_SCHEDULED_CONSENT("PISC_", PISP),
+    PAYMENT_INTERNATIONAL_STANDING_ORDERS_CONSENT("PISOC_", PISP),
+    PAYMENT_FILE_CONSENT("PFC_", PISP),
+
+    FUNDS_CONFIRMATION_CONSENT("FCC_", CBPII);
+
+    private String intentIdPrefix;
+    private OBGroupName obGroupName;
+
+    IntentType(String intentIdPrefix, OBGroupName obGroupName) {
+        this.intentIdPrefix = intentIdPrefix;
+        this.obGroupName = obGroupName;
+    }
+
+    public OBGroupName getObGroupName() {
+        return obGroupName;
+    }
+
+    public String generateIntentId() {
+        String intentId = intentIdPrefix + UUID.randomUUID().toString();
+        return intentId.substring(0, Math.min(intentId.length(), 40));
+    }
+
+    public static List<IntentType> byOBGroupeName(OBGroupName obGroupName) {
+        return Arrays.asList(IntentType.values()).stream().filter(i -> i.obGroupName == obGroupName).collect(Collectors.toList());
+    }
+}

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/api/payment/v3_1_5/domesticpayments/DomesticPaymentConsentsApi.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/api/payment/v3_1_5/domesticpayments/DomesticPaymentConsentsApi.java
@@ -95,8 +95,11 @@ public interface DomesticPaymentConsentsApi {
             @ApiParam(value = "Indicates the user-agent that the PSU is using.")
             @RequestHeader(value = "x-customer-user-agent", required = false) String xCustomerUserAgent,
 
-            @ApiParam(value = "The PISP ID")
-            @RequestHeader(value = "x-ob-client-id", required = false) String clientId,
+            @ApiParam(value = "The TPP ID")
+            @RequestHeader(value = "x-ob-tpp-id", required = true) String tppId,
+
+            @ApiParam(value = "The TPP Name")
+            @RequestHeader(value = "x-ob-tpp-name", required = true) String tppName,
 
             HttpServletRequest request,
 

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/api/payment/v3_1_6/domesticpayments/DomesticPaymentConsentsApiController.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/api/payment/v3_1_6/domesticpayments/DomesticPaymentConsentsApiController.java
@@ -26,6 +26,8 @@
 package com.forgerock.securebanking.openbanking.aspsp.api.payment.v3_1_6.domesticpayments;
 
 import com.forgerock.securebanking.openbanking.aspsp.persistence.repository.payments.DomesticConsentRepository;
+import com.forgerock.securebanking.openbanking.aspsp.service.AnalyticsService;
+import com.forgerock.securebanking.openbanking.aspsp.service.balance.FundsAvailabilityService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 
@@ -35,7 +37,9 @@ public class DomesticPaymentConsentsApiController
         extends com.forgerock.securebanking.openbanking.aspsp.api.payment.v3_1_5.domesticpayments.DomesticPaymentConsentsApiController
         implements DomesticPaymentConsentsApi {
 
-    public DomesticPaymentConsentsApiController(DomesticConsentRepository domesticConsentRepository) {
-        super(domesticConsentRepository);
+    public DomesticPaymentConsentsApiController(DomesticConsentRepository domesticConsentRepository,
+                                                FundsAvailabilityService fundsAvailabilityService,
+                                                AnalyticsService analyticsService) {
+        super(domesticConsentRepository, fundsAvailabilityService, analyticsService);
     }
 }

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/persistence/document/account/FRBalance.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/persistence/document/account/FRBalance.java
@@ -40,14 +40,14 @@ import java.util.Date;
 import java.util.Objects;
 
 /**
- * Representation of an account. This model is only useful for the demo
+ * Representation of an account's balance.
  */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Document
-public class FRBalance implements Balance {
+public class FRBalance {
     private final static NumberFormat FORMAT_AMOUNT = new DecimalFormat("#0.00");
 
     @Id
@@ -62,33 +62,26 @@ public class FRBalance implements Balance {
     @LastModifiedDate
     public Date updated;
 
-
-    @Override
     public FRAmount getCurrencyAndAmount() {
         return getBalance().getAmount();
     }
 
-    @Override
     public BigDecimal getAmount() {
         return new BigDecimal(getBalance().getAmount().getAmount());
     }
 
-    @Override
     public String getCurrency() {
         return getBalance().getAmount().getCurrency();
     }
 
-    @Override
     public FRCreditDebitIndicator getCreditDebitIndicator() {
         return getBalance().getCreditDebitIndicator();
     }
 
-    @Override
     public void setAmount(BigDecimal amount) {
         getBalance().getAmount().setAmount(FORMAT_AMOUNT.format(amount));
     }
 
-    @Override
     public void setCreditDebitIndicator(FRCreditDebitIndicator code) {
         getBalance().setCreditDebitIndicator(code);
     }

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/AnalyticsLogService.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/AnalyticsLogService.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+// TODO #25 - this approach is a starter for ten to get us up and running. We need to configure the logging as per the
+// requirements in https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/25
+/**
+ * Outputs the occurrence of an event/activity to the configured default logger. Each output has a recognised prefix
+ * so that is it easy to identify the analytics events in the logs.
+ */
+@Component
+@Slf4j
+public class AnalyticsLogService implements AnalyticsService {
+
+    // TODO #25 - we may not need this prefix
+    private static final String PREFIX = "ANALYTICS: ";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void recordActivity(String text, Object... arguments) {
+        log.info(PREFIX + text, arguments);
+    }
+}

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/AnalyticsService.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/AnalyticsService.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.service;
+
+/**
+ * Interface for various metrics to be captured (e.g. for TPP requests to be recorded so that they can be analysed).
+ */
+public interface AnalyticsService {
+
+    /**
+     * Records the occurrence of an action/event (which should be clearly described by the provided 'text'
+     * {@link String} parameter). Any additional arguments should have '{}' placeholders within the provided
+     * {@link String}, so that they are included within the resulting output (i.e. as per the slf4j format).
+     *
+     * @param text A {@link String} describing the activity, with optional '{}' placeholders for additional arguments.
+     * @param arguments One or more optional arguments that are included in the resulting output.
+     */
+    void recordActivity(String text, Object... arguments);
+}

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/balance/BalanceStoreService.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/balance/BalanceStoreService.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.service.balance;
+
+import com.forgerock.securebanking.openbanking.aspsp.persistence.document.account.FRBalance;
+import com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.common.FRBalanceType;
+import com.forgerock.securebanking.openbanking.aspsp.persistence.repository.accounts.balances.FRBalanceRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Service for saving and retrieving {@link FRBalance} objects to/from the MongoDB repository.
+ */
+@Service
+@Slf4j
+public class BalanceStoreService {
+
+    private final FRBalanceRepository balanceRepository;
+
+    public BalanceStoreService(FRBalanceRepository balanceRepository) {
+        this.balanceRepository = balanceRepository;
+    }
+
+    /**
+     * Retrieves an {@link FRBalance} based on it's ID and type.
+     *
+     * @param accountId The ID of the {@link FRBalance} to retrieve.
+     * @param balanceType The type of the {@link FRBalance} to retrieve.
+     * @return An {@link Optional} containing the {@link FRBalance} if it's found.
+     */
+    public Optional<FRBalance> getBalance(String accountId, FRBalanceType balanceType) {
+        log.debug("Read balances for account {}", accountId);
+        return balanceRepository.findByAccountIdAndBalanceType(accountId, balanceType);
+    }
+
+    /**
+     * Updates a {@link FRBalance} instance in the Repository.
+     *
+     * @param balance The {@link FRBalance} to update.
+     */
+    public void updateBalance(FRBalance balance) {
+        log.debug("Save balance {}", balance);
+        balanceRepository.save(balance);
+    }
+}

--- a/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/balance/FundsAvailabilityService.java
+++ b/securebanking-openbanking-aspsp-simulator/src/main/java/com/forgerock/securebanking/openbanking/aspsp/service/balance/FundsAvailabilityService.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.service.balance;
+
+import com.forgerock.securebanking.openbanking.aspsp.persistence.document.account.FRBalance;
+import com.google.common.base.Preconditions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.common.FRBalanceType.INTERIMAVAILABLE;
+
+@Service
+@Slf4j
+public class FundsAvailabilityService {
+
+    private final BalanceStoreService balanceStoreService;
+
+    public FundsAvailabilityService(BalanceStoreService balanceStoreService) {
+        this.balanceStoreService = balanceStoreService;
+    }
+
+    /**
+     * Determines if an account has the provided amount available.
+     *
+     * @param accountId The ID of the account in questio
+     * @param amount A {@link String} representing a decimal amount (e.g. 10.00).
+     * @return {@code true} if the account has the required funds.
+     */
+    public boolean isFundsAvailable(String accountId, String amount) {
+        Preconditions.checkArgument(!StringUtils.isEmpty(accountId), "Account Id cannot be empty");
+        Preconditions.checkArgument(!StringUtils.isEmpty(amount), "Amount cannot be empty");
+
+        Optional<FRBalance> balanceIf = balanceStoreService.getBalance(accountId, INTERIMAVAILABLE);
+
+        // Verify account for a balance
+        FRBalance balance = balanceIf.orElseThrow(() -> new IllegalStateException("No balance found of type '"
+                + INTERIMAVAILABLE + "' for account id '" + accountId + "'"));
+        BigDecimal currentBalance = balance.getAmount();
+        BigDecimal requestAmount = new BigDecimal(amount);
+
+        log.debug("Check if balance: '{}' from accountId: '{}' is sufficient to cover the amount: '{}'",
+                currentBalance.toPlainString(), accountId, amount);
+        return (currentBalance.compareTo(requestAmount) >= 0);
+    }
+}

--- a/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/service/balance/FundsAvailabilityServiceTest.java
+++ b/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/service/balance/FundsAvailabilityServiceTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.service.balance;
+
+import com.forgerock.securebanking.openbanking.aspsp.persistence.document.account.FRBalance;
+import com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.FRCashBalance;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.common.FRBalanceType.INTERIMAVAILABLE;
+import static com.forgerock.securebanking.openbanking.aspsp.testsupport.FRCashBalanceTestDataFactory.aValidFRCashBalance;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * Unit test for {@link FundsAvailabilityService}.
+ */
+@ExtendWith(MockitoExtension.class)
+public class FundsAvailabilityServiceTest {
+
+    @Mock
+    private BalanceStoreService balanceStoreService;
+
+    @InjectMocks
+    private FundsAvailabilityService fundsAvailabilityService;
+
+    @Test
+    public void shouldBeFundsAvailableGivenSufficientBalance() {
+        // Given
+        FRCashBalance cashBalance = aValidFRCashBalance();
+        String accountId = cashBalance.getAccountId();
+        FRBalance balance = FRBalance.builder()
+                .accountId(accountId)
+                .balance(cashBalance)
+                .build();
+        given(balanceStoreService.getBalance(accountId, cashBalance.getType())).willReturn(Optional.of(balance));
+
+        // When
+        boolean isFundsAvailable = fundsAvailabilityService.isFundsAvailable(accountId, "9.00");
+
+        // Then
+        assertThat(isFundsAvailable).isTrue();
+    }
+
+    @Test
+    public void shouldNotBeFundsAvailableGivenInsufficientBalance() {
+        // Given
+        FRCashBalance cashBalance = aValidFRCashBalance();
+        String accountId = cashBalance.getAccountId();
+        FRBalance balance = FRBalance.builder()
+                .accountId(accountId)
+                .balance(cashBalance)
+                .build();
+        given(balanceStoreService.getBalance(accountId, cashBalance.getType())).willReturn(Optional.of(balance));
+
+        // When
+        boolean isFundsAvailable = fundsAvailabilityService.isFundsAvailable(accountId, "11.00");
+
+        // Then
+        assertThat(isFundsAvailable).isFalse();
+    }
+
+    @Test
+    public void shouldFailToVerifyFundsAvailableGivenNoBalanceFound() {
+        // Given
+        String accountId = "1234";
+        given(balanceStoreService.getBalance(accountId, INTERIMAVAILABLE)).willReturn(Optional.empty());
+
+        // When
+        IllegalStateException exception = catchThrowableOfType(() ->
+                fundsAvailabilityService.isFundsAvailable(accountId, "10.00"), IllegalStateException.class);
+
+        // Then
+        assertThat(exception.getMessage()).isEqualTo("No balance found of type 'InterimAvailable' for account id '1234'");
+    }
+}

--- a/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/testsupport/FRAmountTestDataFactory.java
+++ b/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/testsupport/FRAmountTestDataFactory.java
@@ -18,26 +18,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.forgerock.securebanking.openbanking.aspsp.persistence.document.account;
+package com.forgerock.securebanking.openbanking.aspsp.testsupport;
 
-
-import com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.common.FRCreditDebitIndicator;
 import com.forgerock.securebanking.openbanking.aspsp.persistence.domain.common.FRAmount;
 
-import java.math.BigDecimal;
+/**
+ * Test data factory for {@link FRAmount}.
+ */
+public class FRAmountTestDataFactory {
 
-public interface Balance {
+    /**
+     * @return a valid instance of {@link FRAmount}
+     */
+    public static FRAmount aValidFRAmount() {
+        return aValidFRAmountBuilder().build();
+    }
 
-    FRAmount getCurrencyAndAmount();
-
-    BigDecimal getAmount();
-
-    String getCurrency();
-
-    FRCreditDebitIndicator getCreditDebitIndicator();
-
-    void setAmount(BigDecimal amount);
-
-    void setCreditDebitIndicator(FRCreditDebitIndicator code);
-
+    /**
+     * @return an instance of {@link FRAmount.FRAmountBuilder} with the required values populated.
+     */
+    public static FRAmount.FRAmountBuilder aValidFRAmountBuilder() {
+        return FRAmount.builder()
+                .currency("GBP")
+                .amount("10.00");
+    }
 }

--- a/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/testsupport/FRCashBalanceTestDataFactory.java
+++ b/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/testsupport/FRCashBalanceTestDataFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.testsupport;
+
+import com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.FRCashBalance;
+import org.joda.time.DateTime;
+
+import static com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.common.FRBalanceType.INTERIMAVAILABLE;
+import static com.forgerock.securebanking.openbanking.aspsp.persistence.domain.account.common.FRCreditDebitIndicator.CREDIT;
+import static com.forgerock.securebanking.openbanking.aspsp.testsupport.FRAmountTestDataFactory.aValidFRAmount;
+
+/**
+ * Test data factory for {@link FRCashBalance}.
+ */
+public class FRCashBalanceTestDataFactory {
+
+    /**
+     * @return a valid instance of {@link FRCashBalance}
+     */
+    public static FRCashBalance aValidFRCashBalance() {
+        return aValidFRCashBalanceBuilder()
+                .build();
+    }
+
+    /**
+     * @return an instance of {@link FRCashBalance.FRCashBalanceBuilder} with the required values populated.
+     */
+    public static FRCashBalance.FRCashBalanceBuilder aValidFRCashBalanceBuilder() {
+        return FRCashBalance.builder()
+                .accountId("12345")
+                .creditDebitIndicator(CREDIT)
+                .type(INTERIMAVAILABLE)
+                .dateTime(DateTime.now())
+                .amount(aValidFRAmount());
+    }
+}

--- a/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/testsupport/api/HttpHeadersTestDataFactory.java
+++ b/securebanking-openbanking-aspsp-simulator/src/test/java/com/forgerock/securebanking/openbanking/aspsp/testsupport/api/HttpHeadersTestDataFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.forgerock.securebanking.openbanking.aspsp.testsupport.api;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * A test data factory for {@link HttpHeaders} that are sent in each HTTP request.
+ */
+public class HttpHeadersTestDataFactory {
+
+    /**
+     * @return an instance of {@link HttpHeaders} with the minimal set of required headers.
+     */
+    public static HttpHeaders requiredHttpHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(singletonList(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth("dummyAuthToken");
+        headers.add("x-idempotency-key", UUID.randomUUID().toString());
+        headers.add("x-jws-signature", "dummyJwsSignature");
+        headers.add("x-ob-tpp-id", "tppId");
+        headers.add("x-ob-tpp-name", "tppName");
+        return headers;
+    }
+}


### PR DESCRIPTION
This PR introduces these changes:

 - Renamed `clientId` header to `tppId`
 - New `tppName` header
 - Checking balance when saving payment consent
 - Provisional logging for analytics

**Issue**: SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit#6